### PR TITLE
Allow http ORCIDs

### DIFF
--- a/CFF-Core/schema.yaml
+++ b/CFF-Core/schema.yaml
@@ -166,7 +166,7 @@ schema;person:
     orcid:
       required: False
       type: str
-      pattern: "https://orcid\\.org/[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]{1}"
+      pattern: "https?://orcid\\.org/[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]{1}"
 
     email:
       required: False


### PR DESCRIPTION
The current schema only allows https for orcids. This PR relaxes the regular expression to allow http as well.

Note that the 1.0.3 specification does seem to favor https, so this might not actually be a good idea. However it seems like for most applications the protocol should be irrelevant.